### PR TITLE
Added 50052 port to be open for Config Validator

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -348,7 +348,7 @@ resource "google_compute_firewall" "forseti-server-allow-grpc" {
 
   allow {
     protocol = "tcp"
-    ports    = ["50051"]
+    ports    = ["50051", "50052"]
   }
 
   depends_on = ["null_resource.services-dependency"]


### PR DESCRIPTION
50052 port is required when we have Config Validator needs to run. I have installed forseti on network where these ports get open depend on firewall rule. So need this port to be added as part of firewall rule.